### PR TITLE
Use `320px` for chrome extension's total width, instead of `360px`

### DIFF
--- a/src/styles/GlobalStyle.jsx
+++ b/src/styles/GlobalStyle.jsx
@@ -12,7 +12,7 @@ const GlobalStyle = () => (
       }
 
       body {
-        width: 360px;
+        width: 320px;
         min-height: 600px;
         background-color: ${style.common.background};
         color: ${style.common.color};


### PR DESCRIPTION
## Why
- Use `320px` for chrome extension's total width, instead of `360px`

## What
- Use `320px` for width in <body />, instead of `360px`
