### PR TITLE
Use `box-shadow` for Design QA, instead of `border`

### DIFF
--- a/src/styles/GlobalStyle.jsx
+++ b/src/styles/GlobalStyle.jsx
@@ -18,7 +18,7 @@ const GlobalStyle = () => (
         background-color: ${style.common.background};
         color: ${style.common.color};
         /* 임시 : 디자인 QA용 */
-        /* border: 1px solid #FFFFFF;  */
+        /* box-shadow: 0 0 0 1px #ffffff; */
       }
 
       button {


### PR DESCRIPTION
- border의 경우, border box 안쪽에 그려지므로, 기존 레이아웃이 깨진다.
- 반면, box-shadow의 경우, border box 바깥쪽으로 그려지므로, 기존 레이아웃 유지된다.
- 따라서, 제대로된 Design QA가 가능하다.
