### PR TITLE
Hide `white left border` by setting 16px

### DIFF
--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -81,7 +81,7 @@ const PreviewContainer = styled.div`
 
   background: ${style.colors.white};
   box-shadow: 0px 4px 4px 4px rgba(0, 0, 0, 0.05);
-  border-radius: 15px;
+  border-radius: 16px 15px 15px 16px;
 
   display: flex;
 


### PR DESCRIPTION
## Why
- border-radius 가 15px 일 경우, 아래 그림처럼 preview 썸네일의 배경색이 색상이 있을 때, 왼쪽에 하얀 줄이 생겼다.
<img width="384" alt="스크린샷 2021-07-16 오전 12 15 09" src="https://user-images.githubusercontent.com/60481383/125812696-2c43a329-40da-4ecb-9113-1284adcc2fb0.png">


## What
- 이를 숨기기 위해 16px로 적용해서, 아래 그림처럼 이제 안 보인다.
<img width="474" alt="스크린샷 2021-07-16 오전 12 13 48" src="https://user-images.githubusercontent.com/60481383/125812447-d6aadcdf-d454-46d3-b463-2b1f34f26ba1.png">
